### PR TITLE
Explicitly specify section for .eh_frame

### DIFF
--- a/microbian/device.ld
+++ b/microbian/device.ld
@@ -17,6 +17,7 @@ SECTIONS {
         KEEP(*(.vectors))
         *(.text*)
         *(.rodata*)
+        *(.eh_frame)
         . = ALIGN(4);
         __etext = .;
     } > FLASH


### PR DESCRIPTION
Fixes error ld: "section .eh_frame LMA [00001f68,00001f9b] overlaps section .data LMA [00001f68,00001f7b]
collect2: error: ld returned 1 exit status"
This error appears when building examples that use microbian for micro:bit v2 